### PR TITLE
Account for all possible Yarn LockManifest fields

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -354,10 +354,14 @@ func isValidPropValueToken(token _Token) bool {
 }
 
 type LockFile map[string]struct {
-	Dependencies map[string]string `json:"dependencies,omitempty"`
-	Integrity    string            `json:"integrity,omitempty"`
-	Resolved     string            `json:"resolved,omitempty"`
-	Version      string            `json:"version,omitempty"`
+	Name                 string            `json:"name,omitempty"`
+	Version              string            `json:"version,omitempty"`
+	UID                  string            `json:"uid,omitempty"`
+	Resolved             string            `json:"resolved,omitempty"`
+	Integrity            string            `json:"integrity,omitempty"`
+	Registry             string            `json:"registry,omitempty"`
+	Dependencies         map[string]string `json:"dependencies,omitempty"`
+	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 }
 
 // RootElement returns elements which not be referenced. The result list is sorted.


### PR DESCRIPTION
There are additional fields that can possibly show up in a Yarn LockManifest object:
https://github.com/yarnpkg/yarn/blob/master/src/lockfile/index.js#L56-L64

This adds those fields to the LockFile type and sorts the keys according to Yarn's preferred sort order:
https://github.com/yarnpkg/yarn/blob/master/src/lockfile/stringify.js#L27-L35